### PR TITLE
Handle CH API response with no address

### DIFF
--- a/lib/defra_ruby/companies_house/api.rb
+++ b/lib/defra_ruby/companies_house/api.rb
@@ -103,6 +103,7 @@ module DefraRuby
       # rubocop:disable Naming/VariableNumber
       def registered_office_address_lines
         address = companies_house_api_response[:registered_office_address]
+        return [] unless address.keys.length.positive?
 
         [
           address[:address_line_1],


### PR DESCRIPTION
This change handles Companies House responses which do not include an address. This can happen for registered societies for example.
https://eaflood.atlassian.net/browse/RUBY-3441